### PR TITLE
First pre-commit hooks

### DIFF
--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -212,7 +212,7 @@ jobs:
       if: env.RELEASE_RUN == 'false'
       run: |
         if [ -n "$(git status --porcelain docs/api_reference docs/index.md)" ]; then
-          echo -e "\u274c Discrepancies found !"
+          echo -e "\u27b0 Discrepancies found !"
           echo -e "The following files in the documentation will be committed:"
           git status --porcelain docs/api_reference docs/index.md
 
@@ -226,7 +226,7 @@ jobs:
           git commit -m "[bot] Update documentation"
           echo "UPDATE_DEFAULT_BRANCH=true" >> $GITHUB_ENV
         else
-          echo -e "\u2705 All good !"
+          echo -e "\u2714 All good !"
           echo "UPDATE_DEFAULT_BRANCH=false" >> $GITHUB_ENV
         fi
       working-directory: ./main

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,7 +21,7 @@
 
 - id: docs-landing-page
   name: Update Landing Page (index.md) for Documentation
-  entry: "invoke create-docs-index --repo-folder=."
+  entry: "invoke create-docs-index --pre-commit --repo-folder=."
   language: python
   files: ^README.md$
   exclude: ^$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,41 @@
+# pre-commit hooks available at https://github.com/CasperWA/ci-cd
+
+- id: docs-api-reference
+  name: Update API Reference in Documentation
+  entry: "invoke create-api-reference-docs --pre-clean --pre-commit --repo-folder=."
+  language: python
+  files: \.py$
+  exclude: ^$
+  types: [file, python]
+  types_or: []
+  exclude_types: []
+  always_run: false
+  fail_fast: false
+  verbose: false
+  pass_filenames: false
+  require_serial: false
+  description: "Update the API Reference documentation whenever a Python file is touched in the code base."
+  language_version: default
+  minimum_pre_commit_version: "2.16.0"
+  args: []
+
+- id: docs-landing-page
+  name: Update Landing Page (index.md) for Documentation
+  entry: "invoke create-docs-index --repo-folder=."
+  language: python
+  files: ^README.md$
+  exclude: ^$
+  types: [file, markdown]
+  types_or: []
+  exclude_types: []
+  always_run: false
+  fail_fast: false
+  verbose: false
+  pass_filenames: false
+  require_serial: false
+  description: "Update the landing page (index.md) for the documentation if the source file (README.md) is changed."
+  language_version: default
+  minimum_pre_commit_version: "2.16.0"
+  args:
+    - "--replacements"
+    - "(LICENSE),(LICENSE.md)"

--- a/docs/hooks/docs_api_reference.md
+++ b/docs/hooks/docs_api_reference.md
@@ -1,0 +1,46 @@
+# Update API Reference in Documentation
+
+**pre-commit hook `id`:** `docs-api-reference`
+
+Run this hook to update the API Reference section of your documentation.
+
+The hook walks through a package directory, finding all Python files and creating a markdown file matching it along with recreating the Python API tree under the `docs/api_reference/` folder.
+
+The hook will run when any Python file is changed in the repository.
+
+The hook expects the documentation to be setup with the [MkDocs](https://www.mkdocs.org) framework, including the [mkdocstrings](https://mkdocstrings.github.io/) plugin for parsing in the Python class/function and method doc-strings, as well as the [awesome-pages](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin) plugin for providing proper titles in the table-of-contents navigation.
+
+## Expectations
+
+It is **required** to specify the `--package-dir` argument through the `args` key.
+
+Otherwise, as noted above, without the proper framework, the created markdown files will not bring about the desired result in a built documentation.
+
+## Options
+
+Any of these options can be given through the `args` key when defining the hook.
+
+| **Name** | **Description** | **Required** | **Default** | **Type** |
+|:--- |:--- |:---:|:---:|:---:|
+| `--package-dir` | Relative path to package dir from the repository root, e.g., 'src/my_package'. | **_Yes_** | | _string_ |
+| `--docs-folder` | The folder name for the documentation root folder. | No | docs | _string_ |
+| `--unwanted-dirs` | Comma-separated list of directories to avoid including into the Python API reference documentation.</br></br>**Note**: Only directory names, not paths, may be included.</br></br>**Note**: All folders and their contents with these names will be excluded. | No | \_\_pycache\_\_ | _string_ |
+| `--unwanted-files` | Comma-separated list of files to avoid including into the Python API reference documentation.</br></br>**Note**: Only full file names, not paths, may be included, i.e., filename + file extension.</br></br>**Note**: All files with these names will be excluded. | No | \_\_init\_\_.py | _string_ |
+| `--full-docs-dirs` | Comma-separated list of directories in which to include everything - even those without documentation strings. This may be useful for a module full of data models or to ensure all class attributes are listed. | No | _Empty string_ | _string_ |
+| `--debug` | Whether or not to print debug statements. | No | `False` | _boolean_ |
+
+## Usage example
+
+The following is an example of how an addition of the _Update API Reference in Documentation_ hook into a `.pre-commit-config.yaml` file may look.
+It is meant to be complete as is.
+
+```yaml
+repos:
+  - repo: https://github.com/CasperWA/ci-cd
+    rev: v1
+    hooks:
+    - id: docs-api-reference
+      args:
+      - '--package-dir="my_python_package"'
+      - '--full-docs-dirs="models"'
+```

--- a/docs/hooks/docs_api_reference.md
+++ b/docs/hooks/docs_api_reference.md
@@ -1,6 +1,6 @@
 # Update API Reference in Documentation
 
-**pre-commit hook `id`:** `docs-api-reference`
+**pre-commit hook _id_:** `docs-api-reference`
 
 Run this hook to update the API Reference section of your documentation.
 

--- a/docs/hooks/docs_landig_page.md
+++ b/docs/hooks/docs_landig_page.md
@@ -1,6 +1,6 @@
 # Update Landing Page (index.md) for Documentation
 
-**pre-commit hook `id`:** `docs-landing-page`
+**pre-commit hook _id_:** `docs-landing-page`
 
 Run this hook to update the landing page (root `index.md` file) for your documentation.
 

--- a/docs/hooks/docs_landig_page.md
+++ b/docs/hooks/docs_landig_page.md
@@ -1,0 +1,44 @@
+# Update Landing Page (index.md) for Documentation
+
+**pre-commit hook `id`:** `docs-landing-page`
+
+Run this hook to update the landing page (root `index.md` file) for your documentation.
+
+The hook copies the root `README.md` file into the root of your documentation folder, renaming it to `index.md` and implementing any replacements specified.
+
+The hook will run when the root `README.md` file is changed in the repository.
+
+The hook expects the documentation to be a framework that can build markdown files for deploying a documentation site.
+
+## Expectations
+
+It is **required** that the root `README.md` exists and the documentation's landing page is named `index.md` and can be found in the root of the documentation folder.
+
+## Options
+
+Any of these options can be given through the `args` key when defining the hook.
+
+| **Name** | **Description** | **Required** | **Default** | **Type** |
+|:--- |:--- |:---:|:---:|:---:|
+| `--docs-folder` | The folder name for the documentation root folder. | No | docs | _string_ |
+| `--replacements` | List of replacements (mappings) to be performed on `README.md` when creating the documentation's landing page (`index.md`). This list _always_ includes replacing '`--docs-folder`/' with an empty string to correct relative links. | No | (LICENSE),(LICENSE.md) | _string_ |
+| `--replacements-separator` | String to separate replacement mappings from the `--replacements` input. Defaults to a pipe (`\|`). | No | \| | _string_ |
+| `--internal-separator` | String to separate a single mapping's 'old' to 'new' statement. Defaults to a comma (`,`). | No | , | _string_ |
+
+## Usage example
+
+The following is an example of how an addition of the _Update Landing Page (index.md) for Documentation_ hook into a `.pre-commit-config.yaml` file may look.
+It is meant to be complete as is.
+
+```yaml
+repos:
+  - repo: https://github.com/CasperWA/ci-cd
+    rev: v1
+    hooks:
+    - id: docs-landing-page
+      args:
+      # Replace `(LICENSE)` with `(LICENSE.md)` (i.e., don't overwrite the default)
+      # Replace `(tools/` with `(`
+      - '--replacements="(LICENSE);(LICENSE.md)|(tools/;("'
+      - '--internal-separator=;'
+```

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,0 +1,12 @@
+# pre-commit Hooks
+
+[pre-commit](https://pre-commit.com) is an excellent tool for running CI tasks prior to committing new changes.
+The tasks are called "hooks" and are run in a separate virtual environment.
+The hooks usually change files in-place, meaning after pre-commit is run during a `git commit` command, the changed files can be reviewed and re-staged and committed.
+
+Through [CasperWA/ci-cd](https://github.com/CasperWA/ci-cd) several hooks are available, mainly related to the [GitHub Actions callable/reusable workflows](../workflows/index.md) that are also available in this repository.
+
+This section contains all the available pre-commit hooks:
+
+- [Update API Reference in Documentation](./docs_api_reference.md)
+- [Update Landing Page (index.md) for Documentation](./docs_landig_page.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,22 @@
-# GitHub Action reusable workflows
+# CI/CD tools
 
 **Current version to use:** `v1`
+
+Use tried and tested continuous integration (CI) and continuous deployment (CD) tools from this repository.
+
+Currently, the repository offers GitHub Actions callable/reusable workflows and [pre-commit](https://pre-commit.com) hooks.
+
+## GitHub Action callable/reusable workflows
 
 This repository contains reusable workflows for GitHub Actions.
 
 They are mainly for usage with modern Python package repositories.
 
-## Available workflows
+### Available workflows
 
-The callable, reusable workflows available from this repository are described in detail in this documentation under the "Workflows" section.
+The callable, reusable workflows available from this repository are described in detail in this documentation under the [Workflows](./workflows/index.md) section.
 
-## General usage
+### General usage
 
 See the [GitHub Docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow) on the topic of calling a reusable workflow to understand how one can incoporate one of these workflows in your workflow.
 
@@ -18,7 +24,25 @@ See the [GitHub Docs](https://docs.github.com/en/actions/using-workflows/reusing
     Workflow-level set `env` context variables cannot be used when setting input values for the called workflow.
     See the [GitHub documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#env-context) for more information on the `env` context.
 
-Under the "Workflows" section for each available workflow, a usage example will be given.
+Under the [Workflows](./workflows/index.md) section for each available workflow, a usage example will be given.
+
+## pre-commit hooks
+
+This repository contains hooks for keeping the documentation up-to-date, making available a few [invoke](https://pyinvoke.org) tasks used in the reusable workflows.
+
+By implementing and using these hooks together with the workflows, one may ensure no extra commits are created during the workflow run to update the documentation.
+
+### Available hooks
+
+The pre-commit hooks available from this repository are described in detail in this documentation under the [Hooks](./hooks/index.md) section.
+
+<!-- markdownlint-disable-next-line MD024 -->
+### General usage
+
+Add the hooks to your `.pre-commit-config.yaml` file.
+See the [pre-commit webpage](https://pre-commit.com) for more information about how to use pre-commit.
+
+Under the [Hooks](./hooks/index.md) section for each available hook, a usage example will be given.
 
 ## License & copyright
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Use tried and tested continuous integration (CI) and continuous deployment (CD) 
 
 Currently, the repository offers GitHub Actions callable/reusable workflows and [pre-commit](https://pre-commit.com) hooks.
 
-## GitHub Action callable/reusable workflows
+## GitHub Actions callable/reusable Workflows
 
 This repository contains reusable workflows for GitHub Actions.
 

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -35,7 +35,7 @@ The repository contains the following:
 
 ## Inputs
 
-| **Name** | **Descriptions** | **Required** | **Default** | **Type** |
+| **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
@@ -55,7 +55,7 @@ The repository contains the following:
 
 ## Secrets
 
-| **Name** | **Descriptions** | **Required** |
+| **Name** | **Description** | **Required** |
 |:--- |:--- |:---:|
 | `PyPI_token` | A PyPI token for publishing the built package to PyPI.</br></br>**Important**: This is _required_ if both 'python_package' and 'publish_on_pypi' are 'true'. Both are 'true' by default. | **_Yes_ (if 'python_package' and 'publish_on_pypi' are 'true')** |
 | `PAT` | A personal access token (PAT) with rights to update the `release_branch`. This will fallback on `GITHUB_TOKEN`. | No |
@@ -82,6 +82,7 @@ jobs:
       git_username: "Casper Welzel Andersen"
       git_email: "CasperWA@github.com"
       release_branch: stable
+      package_dir: my_python_package
       install_extras: "[dev,build]"
       build_cmd: "pip install flit && flit build"
       tag_message_file: ".github/utils/release_tag_msg.txt"

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -1,8 +1,6 @@
----
-title: CD - Release
----
-<!-- markdownlint-disable-next-line MD025 -->
-# CD - Release (`cd_release.yml`)
+# CD - Release
+
+**File to use:** `cd_release.yml`
 
 There are 2 jobs in this workflow, which run in sequence.
 

--- a/docs/workflows/ci_automerge_prs.md
+++ b/docs/workflows/ci_automerge_prs.md
@@ -1,8 +1,6 @@
----
-title: CI - Activate auto-merging for PRs
----
-<!-- markdownlint-disable-next-line MD025 -->
-# CI - Activate auto-merging for PRs (`ci_automerge_prs.yml`)
+# CI - Activate auto-merging for PRs
+
+**File to use:** `ci_automerge_prs.yml`
 
 Activate auto-merging for a PR.
 

--- a/docs/workflows/ci_automerge_prs.md
+++ b/docs/workflows/ci_automerge_prs.md
@@ -18,7 +18,7 @@ There are no inputs for this workflow.
 
 ## Secrets
 
-| **Name** | **Descriptions** | **Required** |
+| **Name** | **Description** | **Required** |
 |:--- |:--- |:---:|
 | `PAT` | A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`. | No |
 

--- a/docs/workflows/ci_cd_updated_default_branch.md
+++ b/docs/workflows/ci_cd_updated_default_branch.md
@@ -1,8 +1,6 @@
----
-title: CI/CD - New updates to default branch
----
-<!-- markdownlint-disable-next-line MD025 -->
-# CI/CD - New updates to default branch (`ci_cd_updated_default_branch.yml`)
+# CI/CD - New updates to default branch
+
+**File to use:** `ci_cd_updated_default_branch.yml`
 
 Keep your `permanent_dependencies_branch` branch up-to-date with changes in your main development branch, i.e., the `default_repo_branch`.
 

--- a/docs/workflows/ci_cd_updated_default_branch.md
+++ b/docs/workflows/ci_cd_updated_default_branch.md
@@ -31,7 +31,7 @@ The repository contains the following:
 
 ## Inputs
 
-| **Name** | **Descriptions** | **Required** | **Default** | **Type** |
+| **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
@@ -56,7 +56,7 @@ The repository contains the following:
 
 ## Secrets
 
-| **Name** | **Descriptions** | **Required** |
+| **Name** | **Description** | **Required** |
 |:--- |:--- |:---:|
 | `PAT` | A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`. | No |
 
@@ -84,7 +84,7 @@ jobs:
       default_repo_branch: stable
       permanent_dependencies_branch: "ci/dependency-updates"
       update_docs: true
-      package_dir: my-python-package
+      package_dir: my_python_package
       doc_extras: "[docs]"
       exclude_files: __init__.py,config.py
       full_docs_dirs: models

--- a/docs/workflows/ci_check_pyproject_dependencies.md
+++ b/docs/workflows/ci_check_pyproject_dependencies.md
@@ -1,8 +1,6 @@
----
-title: CI - Check pyproject.toml dependencies
----
-<!-- markdownlint-disable-next-line MD025 -->
-# CI - Check pyproject.toml dependencies (`ci_check_pyproject_dependencies.yml`)
+# CI - Check pyproject.toml dependencies
+
+**File to use:** `ci_check_pyproject_dependencies.yml`
 
 This workflow runs an [Invoke](https://pyinvoke.org) task to check dependencies in a `pyproject.toml` file.
 

--- a/docs/workflows/ci_check_pyproject_dependencies.md
+++ b/docs/workflows/ci_check_pyproject_dependencies.md
@@ -20,7 +20,7 @@ The repository contains the following:
 
 ## Inputs
 
-| **Name** | **Descriptions** | **Required** | **Default** | **Type** |
+| **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
@@ -33,7 +33,7 @@ The repository contains the following:
 
 ## Secrets
 
-| **Name** | **Descriptions** | **Required** |
+| **Name** | **Description** | **Required** |
 |:--- |:--- |:---:|
 | `PAT` | A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`. | No |
 

--- a/docs/workflows/ci_update_dependencies.md
+++ b/docs/workflows/ci_update_dependencies.md
@@ -1,9 +1,7 @@
----
-title: CI - Update dependencies PR
----
 <!-- markdownlint-disable MD038 -->
-<!-- markdownlint-disable-next-line MD025 -->
-# CI - Update dependencies PR (`ci_update_dependencies.yml`)
+# CI - Update dependencies PR
+
+**File to use:** `ci_update_dependencies.yml`
 
 This workflow creates a PR if there are any updates in the `permanent_dependencies_branch` branch that have not been included in the `default_repo_branch` branch.
 

--- a/docs/workflows/ci_update_dependencies.md
+++ b/docs/workflows/ci_update_dependencies.md
@@ -28,7 +28,7 @@ There are no expectations of the repo when using this workflow.
 
 ## Inputs
 
-| **Name** | **Descriptions** | **Required** | **Default** | **Type** |
+| **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
@@ -44,7 +44,7 @@ There are no expectations of the repo when using this workflow.
 
 ## Secrets
 
-| **Name** | **Descriptions** | **Required** |
+| **Name** | **Description** | **Required** |
 |:--- |:--- |:---:|
 | `PAT` | A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`. | No |
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,4 +1,4 @@
-# Workflows
+# GitHub Actions callable/reusable Workflows
 
 This section contains all the available callable/reusable workflows:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,9 @@ nav:
   - Workflows:
     - Overview: workflows/index.md
     - ... | flat
+  - '`pre-commit` Hooks':
+    - Overview: hooks/index.md
+    - ... | flat
   - ... | python/**
   - License: LICENSE.md
   - Changelog: CHANGELOG.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,10 +75,10 @@ nav:
   - Home: index.md
   - Workflows:
     - Overview: workflows/index.md
-    - ... | flat
-  - '`pre-commit` Hooks':
+    - ... | flat | workflows/**
+  - Hooks:
     - Overview: hooks/index.md
-    - ... | flat
+    - ... | flat | hooks/**
   - ... | python/**
   - License: LICENSE.md
   - Changelog: CHANGELOG.md

--- a/tasks.py
+++ b/tasks.py
@@ -421,7 +421,7 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
         if result.stdout:
             sys.exit(
                 "\u27b0 The following files have been changed/added/removed:\n\n"
-                f"{result.stdout}\nPlease stage them:\n  git add "
+                f"{result.stdout}\nPlease stage them:\n\n  git add "
                 f"{docs_api_ref_dir.relative_to(basis_dir / repo_folder)}"
             )
         print("\u2714 No changes - your API reference documentation is up-to-date !")

--- a/tasks.py
+++ b/tasks.py
@@ -420,8 +420,8 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
         )
         if result.stdout:
             sys.exit(
-                "\u27b0 The following files have been changed/added:\n\n"
-                f"{result.stdout}\n  Please stage them:    git add "
+                "\u27b0 The following files have been changed/added/removed:\n\n"
+                f"{result.stdout}\nPlease stage them:\n  git add "
                 f"{docs_api_ref_dir.relative_to(basis_dir / repo_folder)}"
             )
         print("\u2714 No changes - your API reference documentation is up-to-date !")
@@ -507,7 +507,7 @@ def create_docs_index(  # pylint: disable=too-many-locals
         )
         if result.stdout:
             sys.exit(
-                f"\u27b0 The landing page has been updated.\n  Please stage it:\n\n"
-                f"    git add {docs_index.relative_to(basis_dir / repo_folder)}"
+                f"\u27b0 The landing page has been updated.\n\nPlease stage it:\n\n"
+                f"  git add {docs_index.relative_to(basis_dir / repo_folder)}"
             )
         print("\u2714 No changes - your landing page is up-to-date !")

--- a/tasks.py
+++ b/tasks.py
@@ -215,7 +215,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
     help={
         "package-dir": (
             "Relative path to package dir from the repository root, "
-            "e.g. 'src/my_package'."
+            "e.g., 'src/my_package'."
         ),
         "pre-clean": "Remove the 'api_reference' sub directory prior to (re)creation.",
         "pre-commit": (
@@ -231,16 +231,16 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             "This defaults to 'docs'."
         ),
         "unwanted-dirs": (
-            "Comma-separated list of directories to avoid including in the Python API "
+            "Comma-separated list of directories to avoid including into the Python API "
             "reference documentation. Note, only directory names, not paths, may be "
             "included. Note, all folders and their contents with these names will be "
             "excluded. Defaults to '__pycache__'."
         ),
         "unwanted-files": (
-            "Comma-separated list of files to avoid including the Python API reference"
-            " documentation. Note, only full file names, not paths, may be included, "
-            "i.e., filename + file extension. Note, all files with these names will "
-            "be excluded. Defaults to '__init__.py'."
+            "Comma-separated list of files to avoid including into the Python API "
+            "reference documentation. Note, only full file names, not paths, may be "
+            "included, i.e., filename + file extension. Note, all files with these "
+            "names will be excluded. Defaults to '__init__.py'."
         ),
         "full-docs-dirs": (
             "Comma-separated list of directories in which to include everything - even"

--- a/tasks.py
+++ b/tasks.py
@@ -420,8 +420,8 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
         )
         if result.stdout:
             sys.exit(
-                "\u27b0 The following files have been changed/added, please stage "
-                f"them:\n\n{result.stdout}\n  git add "
+                "\u27b0 The following files have been changed/added:\n\n"
+                f"{result.stdout}\n  Please stage them:    git add "
                 f"{docs_api_ref_dir.relative_to(basis_dir / repo_folder)}"
             )
         print("\u2714 No changes - your API reference documentation is up-to-date !")
@@ -507,8 +507,7 @@ def create_docs_index(  # pylint: disable=too-many-locals
         )
         if result.stdout:
             sys.exit(
-                f"\u27b0 The landing page has been updated. Please stage: "
-                f"{docs_index.relative_to(basis_dir / repo_folder)} by running:\n\n"
-                f"  git add {docs_index.relative_to(basis_dir / repo_folder)}"
+                f"\u27b0 The landing page has been updated.\n  Please stage it:\n\n"
+                f"    git add {docs_index.relative_to(basis_dir / repo_folder)}"
             )
         print("\u2714 No changes - your landing page is up-to-date !")

--- a/tasks.py
+++ b/tasks.py
@@ -275,9 +275,7 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
 
     basis_dir = REPO_DIR if pre_commit else REPO_PARENT_DIR
     package_dir: Path = basis_dir / repo_folder / package_dir
-    docs_api_ref_dir: Path = (
-        basis_dir / repo_folder / docs_folder / "api_reference"
-    )
+    docs_api_ref_dir: Path = basis_dir / repo_folder / docs_folder / "api_reference"
     if debug:
         print("package_dir:", package_dir, flush=True)
         print("docs_api_ref_dir:", docs_api_ref_dir, flush=True)


### PR DESCRIPTION
Closes #16

Add the first [pre-commit](https://pre-commit.com) hooks.
These hooks will run the [invoke](https://pyinvoke.org) tasks `create-api-reference-docs` and `create-docs-index`. The hook id's will be `docs-api-reference` and `docs-landing-page`, respectively.